### PR TITLE
qzip: fix format-truncation

### DIFF
--- a/utils/qzip.c
+++ b/utils/qzip.c
@@ -470,11 +470,7 @@ int makeOutName(const char *in_name, const char *out_name,
  * parent directory. */
 void mkPath(char *path, const char *dirpath, char *file)
 {
-    size_t len;
-
-    len = strlen(dirpath);
-
-    if (len < MAX_PATH_LEN && strlen(file) < MAX_PATH_LEN - len) {
+    if (strlen(dirpath) + strlen(file) + 1 < MAX_PATH_LEN) {
         snprintf(path, MAX_PATH_LEN, "%s/%s", dirpath, file);
     } else {
         assert(0);


### PR DESCRIPTION
GCC 10 turns on -Werror=format-truncation= and errors on
snprintf(path, MAX_PATH_LEN, "%s/%s", dirpath, file):

error: ‘%s’ directive output may be truncated writing up
to 1023 bytes into a region of size between 0 and 1023

The if () misses "/" when counting the max path len so truncation
may happen.

Fixes: #30 

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>