### PR TITLE
Fix: run_perf_test.sh skewed values with stderr

### DIFF
--- a/test/performance_tests/run_perf_test.sh
+++ b/test/performance_tests/run_perf_test.sh
@@ -1,3 +1,6 @@
+#! /bin/bash
+set -e
+
 #***************************************************************************
 #
 #   BSD LICENSE
@@ -32,9 +35,6 @@
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #**************************************************************************
-
-#! /bin/bash
-set -e
 
 CURRENT_PATH=`dirname $(readlink -f "$0")`
 
@@ -77,7 +77,7 @@ thread=4
 echo > result_comp
 for((numProc_comp = 0; numProc_comp < $process; numProc_comp ++))
 do
-    $QZ_ROOT/test/test -m 4 -l 1000 -t 4 -D comp >> result_comp 2>&1  &
+    $QZ_ROOT/test/test -m 4 -l 1000 -t 4 -D comp >> result_comp &
 done
 wait
 compthroughput=`awk '{sum+=$8} END{print sum}' result_comp`
@@ -86,7 +86,7 @@ echo "compthroughput=$compthroughput Gbps"
 echo > result_decomp
 for((numProc_decomp = 0; numProc_decomp < $process; numProc_decomp ++))
 do
-    $QZ_ROOT/test/test -m 4 -l 1000 -t $thread -D decomp >> result_decomp 2>&1  &
+    $QZ_ROOT/test/test -m 4 -l 1000 -t $thread -D decomp >> result_decomp &
 done
 wait
 decompthroughput=`awk '{sum+=$8} END{print sum}' result_decomp`


### PR DESCRIPTION
Problem:
Previously, any stderr would be written to result_comp and result_decomp.  Since
throughput is calculated with `awk ... result_comp`, stderr messages can
vastly skew the reported compthroughput value. This problem is also
theoretically possible for decompthroughput, but it was not observed

Fix:
Only write stdout to resukt_comp and result_decomp, NOT stderr.

Also:
The shebang has been moved to the top of the file. Without this change,
run_perf_test.sh would give the following error and the script would not run
propery:

```
QATzip/test/performance_tests/run_perf_test.sh: 54: QATzip/test/performance_tests/run_perf_test.sh: [[: not found
```