### PR TITLE
run_perf_test: moved shebang to top of file

### DIFF
--- a/test/performance_tests/run_perf_test.sh
+++ b/test/performance_tests/run_perf_test.sh
@@ -1,3 +1,6 @@
+#! /bin/bash
+set -e
+
 #***************************************************************************
 #
 #   BSD LICENSE
@@ -32,9 +35,6 @@
 #   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 #**************************************************************************
-
-#! /bin/bash
-set -e
 
 CURRENT_PATH=`dirname $(readlink -f "$0")`
 


### PR DESCRIPTION
The shebang has been moved to the top of the file. Without this change,
run_perf_test.sh would give the following error and the script would not run
propery on Ubuntu 18.04 / GNU bash, version 4.4.20:

```
QATzip/test/performance_tests/run_perf_test.sh: 54: QATzip/test/performance_tests/run_perf_test.sh: [[: not found
```
Addresses issue #40 