### PR TITLE
run_perf_test: fix skewed values caused by stderr

### DIFF
--- a/test/performance_tests/run_perf_test.sh
+++ b/test/performance_tests/run_perf_test.sh
@@ -36,6 +36,11 @@
 #! /bin/bash
 set -e
 
+rm -f result_comp
+rm -f result_decomp
+rm -f result_comp_stderr
+rm -f result_decomp_stderr
+
 CURRENT_PATH=`dirname $(readlink -f "$0")`
 
 #get the type of QAT hardware
@@ -77,7 +82,7 @@ thread=4
 echo > result_comp
 for((numProc_comp = 0; numProc_comp < $process; numProc_comp ++))
 do
-    $QZ_ROOT/test/test -m 4 -l 1000 -t 4 -D comp >> result_comp 2>&1  &
+    $QZ_ROOT/test/test -m 4 -l 1000 -t 4 -D comp >> result_comp 2>> result_comp_stderr &
 done
 wait
 compthroughput=`awk '{sum+=$8} END{print sum}' result_comp`
@@ -86,11 +91,9 @@ echo "compthroughput=$compthroughput Gbps"
 echo > result_decomp
 for((numProc_decomp = 0; numProc_decomp < $process; numProc_decomp ++))
 do
-    $QZ_ROOT/test/test -m 4 -l 1000 -t $thread -D decomp >> result_decomp 2>&1  &
+    $QZ_ROOT/test/test -m 4 -l 1000 -t $thread -D decomp >> result_decomp 2>> result_decomp_stderr &
 done
 wait
 decompthroughput=`awk '{sum+=$8} END{print sum}' result_decomp`
 echo "decompthroughput=$decompthroughput Gbps"
 
-rm -f result_comp
-rm -f result_decomp


### PR DESCRIPTION
Previously, any stderr would be written to result_comp and result_decomp.  Since
throughput is calculated with `awk ... result_comp`, stderr messages can
vastly skew the reported compthroughput value. This problem is also
theoretically possible for decompthroughput, but it was not observed.

We fix this by only writing stdout to result_comp and result_decomp, NOT stderr.
Instead, stderr is written to result_comp_stderr/result_decomp_stderr, which
are deleted when this script is invoked.

Addresses issue #42 