### PR TITLE
Fix snprintf truncation check in mkPath

### DIFF
--- a/utils/qzip.c
+++ b/utils/qzip.c
@@ -469,9 +469,9 @@ int makeOutName(const char *in_name, const char *out_name,
  * parent directory. */
 void mkPath(char *path, const char *dirpath, char *file)
 {
-    if (strlen(dirpath) + strlen(file) + 1 < MAX_PATH_LEN) {
-        snprintf(path, MAX_PATH_LEN, "%s/%s", dirpath, file);
-    } else {
+    const int nprinted = snprintf(path, MAX_PATH_LEN, "%s/%s", dirpath, file);
+    if (nprinted >= MAX_PATH_LEN || nprinted < 0) {
+        /* truncated, or output error */
         assert(0);
     }
 }


### PR DESCRIPTION
In the “pre-flight” check to see if truncation will occur in the call to `snprintf()` in `mkPath()` in `utils/qzip.c`, the conditional fails if `MAX_PATH_LEN` does not accommodate both path components plus one additional byte; but two bytes are needed, one for the “`/`” separating the two paths and one for the null terminator.

This is a follow-up to #31, which tried to fix the check but failed to account for the null terminator.

I discovered the problem due to a GCC 12 (pre-release) error with `-Werror=format-truncation`:

```
qzip.c: In function 'mkPath':
qzip.c:472:42: error: '%s' directive output may be truncated writing up to 1022 bytes into a region of size between 1 and 1023 [-Werror=format-truncation=]
  472 |         snprintf(path, MAX_PATH_LEN, "%s/%s", dirpath, file);
      |                                          ^~
In file included from /usr/include/stdio.h:894,
                 from qzip.h:39,
                 from qzip.c:35:
In function 'snprintf',
    inlined from 'mkPath' at qzip.c:472:9:
/usr/include/bits/stdio2.h:71:10: note: '__snprintf_chk' output between 2 and 2046 bytes into a destination of size 1024
   71 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
```