### PR TITLE
Fix compilation warnings with "-Wunused-but-set-variable"

### DIFF
--- a/utils/qzip.c
+++ b/utils/qzip.c
@@ -561,7 +561,7 @@ void processStream(QzSession_T *sess, FILE *src_file, FILE *dst_file,
     off_t dst_file_size = 0;
     unsigned char *src_buffer = NULL;
     unsigned char *dst_buffer = NULL;
-    unsigned int bytes_read = 0, bytes_processed = 0;
+    unsigned int bytes_read = 0;
     unsigned int ratio_idx = 0;
     const unsigned int ratio_limit =
         sizeof(g_bufsz_expansion_ratio) / sizeof(unsigned int);
@@ -607,7 +607,6 @@ void processStream(QzSession_T *sess, FILE *src_file, FILE *dst_file,
             if (!is_compress) {
                 pending_in = bytes_input - bytes_read;
             }
-            bytes_processed += bytes_read;
             if (0 != bytes_read) {
                 if (!is_compress && pending_in > 0) {
                     memmove(src_buffer, src_buffer + bytes_read,

--- a/utils/qzip_7z.c
+++ b/utils/qzip_7z.c
@@ -2825,7 +2825,6 @@ size_t writeSubstreamsInfo(Qz7zSubstreamsInfo_T *substreams, FILE *fp,
 {
     int i, j;
     int total_index = 0;
-    int total_files = 0;
     size_t total_size = 0;
 
     if (!substreams) return 0;
@@ -2834,7 +2833,6 @@ size_t writeSubstreamsInfo(Qz7zSubstreamsInfo_T *substreams, FILE *fp,
     total_size += writeTag(PROPERTY_ID_NUM_UNPACK_STREAM, fp, crc);
 
     for (i = 0; i < substreams->numFolders; ++i) {
-        total_files += substreams->numUnPackStreams[i];
         total_size += writeNumber(substreams->numUnPackStreams[i], fp, crc);
     }
 


### PR DESCRIPTION
This fixes compilation errors such as this:
```
Making all in utils
make[1]: Entering directory '/data1/home/ipuustin/.cache/bazel/_bazel_ipuustin/dcbd858b6cccc7f6a21c2f4a004129a4/sandbox/linux-sandbox/878/execroot/envoy/bazel-out/k8-fastbuild/bin/external/envoy/bazel/foreign_cc/qatzip.build_tmpdir/utils'
  CC       qzip-qzip_7z.o
qzip_7z.c:2828:9: error: variable 'total_files' set but not used [-Werror,-Wunused-but-set-variable]
    int total_files = 0;
        ^
1 error generated.
make[1]: *** [Makefile:498: qzip-qzip_7z.o] Error 1
```
