### PR TITLE
Fix %autosetup command in qatzip.spec.in

### DIFF
--- a/qatzip.spec.in
+++ b/qatzip.spec.in
@@ -46,7 +46,7 @@ This package contains headers and libraries required to build
 applications that use the QATzip APIs.
 
 %prep
-%autosetup -p0 -n %{name}-%{version}
+%autosetup -p0 -n %{githubname}-%{version}
 
 %build
 %set_build_flags


### PR DESCRIPTION
Fix the following error during rpmbuild stage.
The error is due to the source tar-file unpacking to `QATzip-1.0.9` directory.
```
+ cd qatzip-1.0.9
/var/tmp/rpm-tmp.WKMWyN: line 39: cd: qatzip-1.0.9: No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.WKMWyN (%prep)
```