### PR TITLE
Add support for pkg-config in QATzip

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,7 +43,8 @@ SUBDIRS = src utils test
 
 pkgincludedir = $(includedir)
 pkginclude_HEADERS = include/qatzip.h
-
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = qatzip.pc
 dist_man_MANS = \
                 man/qzip.1
 

--- a/configure.ac
+++ b/configure.ac
@@ -286,5 +286,6 @@ AC_CONFIG_FILES([Makefile
                  qatzip.spec
                  src/Makefile
                  test/Makefile
-                 utils/Makefile])
+                 utils/Makefile]
+                 qatzip.pc)
 AC_OUTPUT

--- a/qatzip.pc.in
+++ b/qatzip.pc.in
@@ -1,0 +1,12 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: qatzip
+Description: Higher level library provides access to Intel QAT compression
+URL: https://github.com/intel/QATzip
+Version: @VERSION@
+Libs: -L${libdir} -lqatzip
+Cflags: -I${includedir}
+Requires: zlib, liblz4


### PR DESCRIPTION
Allows easier integration with other apps/libs by offering support for pkg-config tool.