### PR TITLE
README: fix typo lenth -> length

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The compression level in QATzip could be mapped to standard zlib\* as below:
   in the other session.
 * For stream object, user should clear stream object by calling qzEndStream() before clear session
   object with qzTeardownSession(). Otherwise, memory leak happens.
-* For stream object, stream lenth must be smaller than `strm_buff_sz`, or QATzip would generate multiple
+* For stream object, stream length must be smaller than `strm_buff_sz`, or QATzip would generate multiple
   deflate block in order and has the last block with BFIN set.
 * For stream object, we will optimize the performance of the pre-allocation process using a thread-local
   stream buffer list in a future release.


### PR DESCRIPTION
Typo in README. `lenth` should be `length`