### PR TITLE
Fix bug related to minMatch in qzstd

### DIFF
--- a/utils/qzstd.c
+++ b/utils/qzstd.c
@@ -323,6 +323,12 @@ int compressFile(int in_file, int out_file)
     * should be 3. if mini match is 3, then LZ4MINMATCH should be 2*/
     LZ4MINMATCH = g_sess_params.lz4s_mini_match == 4 ? 3 : 2;
 
+    /* Align zstd minmatch to the QAT minmatch */
+    ZSTD_CCtx_setParameter(
+        zc, ZSTD_c_minMatch,
+        g_sess_params.lz4s_mini_match >= 4 ? 4 : 3
+    );
+
     //setup session
     int ret = qzInit(&qzstd_g_sess, g_sess_params.common_params.sw_backup);
     if (ret != QZ_OK && ret != QZ_DUPLICATE) {


### PR DESCRIPTION
When using `ZSTD_compressSequences()`, it's important to make sure that the input sequences do not have any matches shorter than `ZSTD_c_minMatch`. From [the docs](https://github.com/facebook/zstd/blob/64963dcbd6162c52ba9273bb55d78c7a442b12f4/lib/zstd.h#L1546):
```
 *    - ZSTD_c_minMatch MUST be set as less than or equal to the smallest match generated by the match finder. It has a minimum value of ZSTD_MINMATCH_MIN.
```
**Compression can fail if this condition is not satisfied**, because zstd allocates memory for sequences using the assumption that all match lengths are >= `ZSTD_c_minMatch`.

For QAT, this means we need to ensure that `ZSTD_c_minMatch` is not greater than `g_sess_params.lz4s_mini_match`. That's what is accomplished by this PR.

Setting `ZSTD_c_minMatch` won't affect software fallback compression, because qzstd.c is using `ZSTD_compressCCtx()`, which ignores all parameter settings except for compression level.