### PR TITLE
Fix build when building out-of-tree: use $(top_srcdir) in -I flags

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -44,8 +44,8 @@ libqatzip_la_SOURCES = \
                        qatzip_lz4.c \
                        xxhash.c
 libqatzip_la_CFLAGS = \
-                      -I./ \
-                      -I../include/ \
+                      -I$(srcdir) \
+                      -I$(top_srcdir)/include \
                       $(COMMON_CFLAGS) \
                       $(SAL_CFLAGS) \
                       $(ADF_CFLAGS) \


### PR DESCRIPTION
Otherwise, it can't find the sources.