### PR TITLE
fixed block_count calculation error

### DIFF
--- a/src/qatzip.c
+++ b/src/qatzip.c
@@ -1494,7 +1494,7 @@ static int qzLZ4StoredBlocks(QzSess_T *qz_sess, const unsigned char *src,
     //set block size to STORED_BLK_MAX_LEN(64K)
     block_size = STORED_BLK_MAX_LEN;
     block_count = src_len / block_size +
-                  src_len % block_size > 0 ? 1 : 0;
+               (((src_len % block_size) > 0) ? 1 : 0);
     out_len = (outputHeaderSz(data_fmt) +
                (block_count * QZ_LZ4_STORED_HEADER_SIZE) +
                src_len + outputFooterSz(data_fmt));
@@ -1570,7 +1570,7 @@ static int qzDeflateStoredBlocks(QzSess_T *qz_sess, const unsigned char *src,
     DataFormatInternal_T data_fmt = qz_sess->sess_params.data_fmt;
 
     block_count = src_len / block_size +
-                  src_len % block_size > 0 ? 1 : 0;
+               (((src_len % block_size) > 0) ? 1 : 0);
     out_len = (outputHeaderSz(data_fmt) + (block_count * STORED_BLK_HDR_SZ) +
                src_len + outputFooterSz(data_fmt));
     *dest_len -= out_len;


### PR DESCRIPTION
When utilizing the `qzCompress(...)` API and encountering a failure, specifically the `CPA_DC_VERIFY_ERROR` in the `doCompressOut(...)` function, the code invokes `qzDeflateStoredBlocks(...)` to copy data to the destination buffer. This includes the Gzip header, block header, and source data. However, an issue arises in the calculation of the output length (out_len) within the `qzDeflateStoredBlocks(...)` function.

This calculation error is related to the estimation of the block count, resulting in a miscalculation. During testing, despite providing src_len as 131328 (which is twice the size of the block size, 65535), the block count consistently calculates as 1 in the log messages. Ideally, with such a src_len, the block count should be 3.

This miscalculation leads to an underestimated out_len by at least 5 bytes per block, causing a discrepancy between the final *dest_len and total_out_len in the qzCompressCrcExt(...) function. Consequently, this discrepancy triggers the `assert(*dest_len == sess->total_out)` to fail in `qzCompressCrcExt(...)`.

It's worth noting that after modifying the code by adding brackets, there are no longer any assert failures observed in my experiment.

This below is my experiment log about this error:
1. The calculation is 131337  , loss 2 block_header, totoal  10byte.
2. The actual filled data to destination bufffer is 131347.

 ```
**qzStoredBlocks Start **
        src_len: 131328 | block_count: 1
        out_len: 131337 = outputHeaderSz:4 + (block_count * STORED_BLK_HDR_SZ): 5 + src_len: 131328 + outputFooterSz: 0

        This time Store block comsume & produce: 
          resl.produced: 131333 = (block_count * STORED_BLK_HDR_SZ) + src_len; 
          resl.consumed: 131328 = this inst_id.stream.buffer comp fail copy source
        Estimate current qz_sess-> in_len/out_len  
          Estimate: qz_sess->qz_in_len [BF]: 0 + resl.consumed = [AF]: 131328
          Estimate: qz_sess->qz_out_len [BF]: 0 + out_len = [AF]: 131337
        Add Header at head:
             debug_dest_len: 4
  ** StoreBlock while start with src_size: 131328 : **
            Creating the block without final bit
        BLK_HDR_SZ:
             debug_dest_len: 9
        Memcpy src data to dest buf:
             debug_dest_len: 65544
        Calculate used src_len &  left src_len:
            has finish: 65535
            left src_len: 65793
                this block len & block checksum:
            this_block_len: 65535 this block checksum: 10759910
---------------
            Creating the block without final bit
        BLK_HDR_SZ:
             debug_dest_len: 65549
        Memcpy src data to dest buf:
             debug_dest_len: 131084
        Calculate used src_len &  left src_len:
            has finish: 131070
            left src_len: 258
        this block len & block checksum:
            this_block_len: 65535 this block checksum: b52cb222
---------------
        ~~  Creating the final block
        BLK_HDR_SZ:
             debug_dest_len: 131089
        Memcpy src data to dest buf:
             debug_dest_len: 131347
        Calculate used src_len &  left src_len:
            has finish: 131328
            left src_len: 0
        this block len & block checksum:
            this_block_len: 258 this block checksum: 8e100b9a
---------------
  ** StoreBlock while End with src_size: 131328 **
Produce: 
        resl.produced = 0x20105
        outputFooterGen:  
              debug_dest_len: 131347 | Footer_Sz: 0
**      qzStoredBlocks SUCCESS **

//QZ_DEBUG()
**total_in = 131328 total_out = 131337 src_len = 131328 dest_len = 131347**
```