### PR TITLE
Fix -Werror,-Wstrict-prototypes for streamBufferCleanup

### DIFF
--- a/src/qatzip_internal.h
+++ b/src/qatzip_internal.h
@@ -449,7 +449,7 @@ void cleanUpInstMem(int i);
 
 void qzMemDestory(void);
 
-void streamBufferCleanup();
+void streamBufferCleanup(void);
 
 //lz4 functions
 unsigned long qzLZ4HeaderSz(void);

--- a/src/qatzip_stream.c
+++ b/src/qatzip_stream.c
@@ -125,7 +125,7 @@ static inline int removeNodeFromList(StreamBuffNode_T *node,
     return SUCCESS;
 }
 
-void streamBufferCleanup()
+void streamBufferCleanup(void)
 {
     StreamBuffNode_T *node;
     StreamBuffNode_T *next;


### PR DESCRIPTION
Addresses compilation error messages:

  error: a function declaration without a prototype is deprecated
  in all versions of C [-Werror,-Wstrict-prototypes]