### PR TITLE
qatzip_lz4: function declaration without a prototype for qzLZ4HeaderSz

### DIFF
--- a/src/qatzip_lz4.c
+++ b/src/qatzip_lz4.c
@@ -49,12 +49,12 @@
 #include "qatzip_internal.h"
 #include "qz_utils.h"
 
-inline unsigned long qzLZ4HeaderSz()
+inline unsigned long qzLZ4HeaderSz(void)
 {
     return QZ_LZ4_HEADER_SIZE;
 }
 
-inline unsigned long qzLZ4FooterSz()
+inline unsigned long qzLZ4FooterSz(void)
 {
     return QZ_LZ4_FOOTER_SIZE;
 }


### PR DESCRIPTION
On modern compilers it becomes a compilation error with message:

  error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]