### PR TITLE
Fix a couple of trivial spelling mistakes

### DIFF
--- a/src/qatzip_sw.c
+++ b/src/qatzip_sw.c
@@ -765,7 +765,7 @@ int compOutSWFallback(int i, int j, QzSession_T *sess,
         return QZ_FAIL;
     }
 
-    QZ_DEBUG("The request get dummy emty respond, offload to software!\n");
+    QZ_DEBUG("The request get dummy empty respond, offload to software!\n");
     QZ_DEBUG("SW CompOut src_ptr %p, dst_ptr %p, Sending %u bytes, seq = %ld\n",
              src_ptr, dest_ptr, src_send_sz, g_process.qz_inst[i].stream[j].seq);
 

--- a/src/qatzip_utils.c
+++ b/src/qatzip_utils.c
@@ -1018,7 +1018,7 @@ int isQATProcessable(const unsigned char *ptr,
         break;
     case DEFLATE_RAW:
         if (*src_len < qz_sess->sess_params.input_sz_thrshold) {
-            QZ_DEBUG("isQATProcessable: deflate_raw src_len is less than input threshhold\n");
+            QZ_DEBUG("isQATProcessable: deflate_raw src_len is less than input threshold\n");
             rc = 0;
         } else {
             rc = 1;


### PR DESCRIPTION
The Debian lintian checker found two spelling mistakes when packaging up the latest release. Fix these.