### PR TITLE
Fix a couple of trivial spelling mistakes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,8 @@ pkginclude_HEADERS = include/qatzip.h
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = qatzip.pc
 dist_man_MANS = \
-                man/qzip.1
+                man/qzip.1 \
+                man/qatzip-test.1
 
 EXTRA_DIST = \
              LICENSE \


### PR DESCRIPTION
The Debian lintian checker found two spelling mistakes when packaging up the latest release. Fix these.